### PR TITLE
Added post_to_room plugin

### DIFF
--- a/plugins/post_to_room/base-config.yaml
+++ b/plugins/post_to_room/base-config.yaml
@@ -1,0 +1,2 @@
+secret: "addsecretrandomstringhere" # secret parameter that must be provided as GET param otherwise the http request to post a message is rejected
+homeserver: "matrix-bots-wporg.local"

--- a/plugins/post_to_room/maubot.yaml
+++ b/plugins/post_to_room/maubot.yaml
@@ -1,0 +1,11 @@
+maubot: 0.4.2
+id: org.wordpress.post_to_room
+version: 1.0.0
+license: AGPL-3.0-or-later
+config: true
+webapp: true
+extra_files:
+  - base-config.yaml
+modules:
+  - post_to_room
+main_class: PostToRoom

--- a/plugins/post_to_room/post_to_room.py
+++ b/plugins/post_to_room/post_to_room.py
@@ -1,0 +1,60 @@
+from maubot import Plugin
+from maubot.handlers import web
+from aiohttp.web import Request, Response
+from mautrix.util.config import BaseProxyConfig, ConfigUpdateHelper
+from mautrix.types import RoomID, RoomAlias
+from typing import Type
+
+
+class Config(BaseProxyConfig):
+    def do_update(self, helper: ConfigUpdateHelper) -> None:
+        helper.copy("secret")
+        helper.copy("homeserver")
+
+
+class PostToRoom(Plugin):
+    def get_command_name(self) -> str:
+        return self.id
+
+    @classmethod
+    def get_config_class(cls) -> Type[BaseProxyConfig]:
+        return Config
+
+    async def start(self) -> None:
+        await super().start()
+        self.config.load_and_update()
+
+    def get_secret_from_config(self) -> str:
+        return self.config["secret"]
+
+    def get_homeserver_from_config(self) -> str:
+        return self.config["homeserver"]
+
+    # Available at $MAUBOT_URL/_matrix/maubot/plugin/<instance ID>/notify
+    @web.post("/notify")
+    async def post_data(self, request: Request) -> Response:
+        data = await request.json()
+
+        # avoid stray requests
+        if request.rel_url.query["secret"] != self.get_secret_from_config():
+            return Response(status=403)
+
+        room_id = await self.get_room_id(data['room'])
+        await self.client.send_markdown(RoomID(room_id), data['message'])
+        return Response(status=200)
+
+    # acceptable value for room "where":
+    # room alias part such as "core", "#core"
+    # room alias such as "#core:community.wordpress.org"
+    # room id such as "!cHPvPsHiObbVCkAdiy:community.wordpress.org"
+    async def get_room_id(self, where: str) -> str:
+        if where[0] == '!':
+            return where
+
+        if where[0] != '#':
+            room_alias = '#' + where.split(':')[0] + ':' + self.get_homeserver_from_config()
+        else:
+            room_alias = where.split(':')[0] + ':' + self.get_homeserver_from_config()
+
+        room_alias_info = await self.client.resolve_room_alias(RoomAlias(room_alias))
+        return room_alias_info.room_id


### PR DESCRIPTION
This PR adds `post_to_room` plugin, which lets us configure http endpoints `$MAUBOT_URL/_matrix/maubot/plugin/<instance ID>/notify?secret=XXXXXXX` and allow us to pass json request body such as
```
{
  "message": "something happened",
  "room": "#core"
}
```

The room could be either a room id or room alias (local part or full form).